### PR TITLE
Moize published benchmarks for multiple objects using iMemoized incorrect

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -171,7 +171,7 @@ const runMultipleObjectSuite = () => {
   const mFastMemoize = fastMemoize(fibonacciMultipleObject);
   const mAddyOsmani = addyOsmani(fibonacciMultipleObject);
   const mMemoizerific = memoizerific(Infinity)(fibonacciMultipleObject);
-  const mImemoized = imemoized(fibonacciMultipleObject);
+  const mImemoized = imemoized(fibonacciMultipleObject,"isComplete");
   const mFutz = moize(fibonacciMultipleObject);
 
   return new Promise((resolve) => {


### PR DESCRIPTION
The moize published benchmarks for multiple objects using iMemoized were incorrect since they failed to use a documented configuration option with iMemoized that ensures safe, thoughtful memoizing of functions taking objects as arguments. This patch adds the keyProperty argument to iMemoize call in the benchmark index.js file for the multi-object test.