### PR TITLE
Simplify logic for updating cache value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # moize CHANGELOG
 
+## 5.3.1
+
+**BUGFIXES**
+
+- Clean up logic surrounding `update` function to not unnecessarily assign the value twice
+
 ## 5.3.0
 
 **NEW FEATURES**

--- a/README.md
+++ b/README.md
@@ -888,7 +888,7 @@ memoized.add(["foo"], "bar");
 memoized("foo");
 ```
 
-**NOTE**: This will only add `key`s that do not exist in the cache. If you want to update keys that already exist, use [`update`](#updatekey-value).
+**NOTE**: This will only add `key`s that do not exist in the cache, and will do nothing if the `key` already exists. If you want to update keys that already exist, use [`update`](#updatekey-value).
 
 #### clear()
 
@@ -994,7 +994,7 @@ memoized.remove([foo]);
 memoized(foo);
 ```
 
-**NOTE**: This will only remove `key`s that exist in the cache.
+**NOTE**: This will only remove `key`s that exist in the cache, and will do nothing if the `key` does not exist.
 
 #### update(key, value)
 
@@ -1012,7 +1012,7 @@ memoized.add(["foo"], "bar");
 memoized("foo");
 ```
 
-**NOTE**: This will only update `key`s that exist in the cache. If you want to add keys that do not already exist, use [`add`](#addkey-value).
+**NOTE**: This will only update `key`s that exist in the cache, and will do nothing if the `key` does not exist. If you want to add keys that do not already exist, use [`add`](#addkey-value).
 
 #### values()
 

--- a/src/instance.js
+++ b/src/instance.js
@@ -99,9 +99,7 @@ export const addInstanceMethods = (moized: Function, {expirations}: Object): voi
       const existingKey: Array<any> = moized.cache.keys[keyIndex];
 
       orderByLru(moized.cache.keys, existingKey, keyIndex);
-      orderByLru(moized.cache.values, existingKey, keyIndex);
-
-      moized.cache.values[0] = value;
+      orderByLru(moized.cache.values, value, keyIndex);
 
       onCacheChange(moized.cache, moized.options, moized);
     }

--- a/test/instance.js
+++ b/test/instance.js
@@ -658,8 +658,8 @@ test('if moized.update will set the new value in cache for the moized item', (t)
     return value;
   });
 
-  const keys = [['foo'], key];
-  const values = ['bar', value];
+  const keys = [['foo'], [{bar: 'baz'}], key];
+  const values = ['bar', ['quz'], value];
 
   moized.cache = {
     keys: [...keys],
@@ -685,8 +685,8 @@ test('if moized.update will set the new value in cache for the moized item', (t)
 
   moized.update(key, newValue);
 
-  t.deepEqual(moized.cache.keys, [key, keys[0]]);
-  t.deepEqual(moized.cache.values, [newValue, values[0]]);
+  t.deepEqual(moized.cache.keys, [key, ...keys.slice(0, keys.length - 1)]);
+  t.deepEqual(moized.cache.values, [newValue, ...values.slice(0, values.length - 1)]);
 });
 
 test('if moized.update will do nothing if the key does not exist in keys', (t) => {

--- a/test/instance.js
+++ b/test/instance.js
@@ -658,9 +658,12 @@ test('if moized.update will set the new value in cache for the moized item', (t)
     return value;
   });
 
+  const keys = [['foo'], key];
+  const values = ['bar', value];
+
   moized.cache = {
-    keys: [key],
-    values: [value]
+    keys: [...keys],
+    values: [...values]
   };
 
   moized.options = {
@@ -682,8 +685,8 @@ test('if moized.update will set the new value in cache for the moized item', (t)
 
   moized.update(key, newValue);
 
-  t.deepEqual(moized.cache.keys, [key]);
-  t.deepEqual(moized.cache.values, [newValue]);
+  t.deepEqual(moized.cache.keys, [key, keys[0]]);
+  t.deepEqual(moized.cache.values, [newValue, values[0]]);
 });
 
 test('if moized.update will do nothing if the key does not exist in keys', (t) => {


### PR DESCRIPTION
* Remove unnecessary temporary assignment, and just assign the value as part of the reorder
* Include a test to ensure that other keys / values are reorderer properly