### PR TITLE
Improve typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,38 +1,40 @@
-interface Cache {
-  keys: Array<Array<any>>;
-  size: number;
-  values: Array<any>;
-}
+export as namespace moize;
+export = moize;
 
-interface Options {
-  equals?: (cacheKeyArgument: any, keyArgument: any) => boolean; // custom equality comparator comparing a specific key argument
-  isDeepEqual?: boolean; // is key comparison done via deep equality
-  isPromise?: boolean; // is the result a promise
-  isReact?: boolean; // is the method a functional React component
-  isSerialized?: boolean; // should the parameters be serialized instead of directly referenced
-  matchesKey?: (cacheKey: Array<any>, key: Array<any>) => boolean; // custom equality comparator comparing the entire key
-  maxAge?: number; // amount of time in milliseconds before the cache will expire
-  maxArgs?: number; // maximum number of arguments to use as key for caching
-  maxSize?: number; // maximum size of cache for this method
-  onCacheAdd?: (cache: Cache) => void; // a callback when a new cache item is added
-  onCacheChange?: (cache: Cache) => void; // a callback when the cache changes
-  onCacheHit?: (cache: Cache) => void; // a callback when an existing cache item is retrieved
-  onExpire?: (key: any) => void; // a callback when a cache item expires
-  profileName?: string; // a custom name to associate stats for the method to
-  serializer?: (...args: any[]) => any; // provide a serializer and override default,
-  shouldSerializeFunctions?: boolean; // should functions be included in the serialization of multiple parameters
-  transformArgs?: (args: any[]) => any[]; // transform the args prior to storage as key
-  updateExpire?: boolean; // should the expiration be updated when cache is hit
-}
-
-type Fn = (...args: any[]) => any;
-
-type Moizer<T extends Fn> = (t: T) => T;
-
-declare function moize<T extends Fn>(o: Options): ((t: T) => T);
-declare function moize<T extends Fn>(t: T, o?: Options): T;
+declare function moize<T extends moize.Fn>(o: moize.Cache): ((t: T) => T);
+declare function moize<T extends moize.Fn>(t: T, o?: moize.Options): T;
 
 declare namespace moize {
+  export type Fn = (...args: any[]) => any;
+  export type Moizer<T extends Fn> = (t: T) => T;
+
+  export interface Cache {
+    keys: Array<Array<any>>;
+    size: number;
+    values: Array<any>;
+  }
+
+  export interface Options {
+    equals?: (cacheKeyArgument: any, keyArgument: any) => boolean; // custom equality comparator comparing a specific key argument
+    isDeepEqual?: boolean; // is key comparison done via deep equality
+    isPromise?: boolean; // is the result a promise
+    isReact?: boolean; // is the method a functional React component
+    isSerialized?: boolean; // should the parameters be serialized instead of directly referenced
+    matchesKey?: (cacheKey: Array<any>, key: Array<any>) => boolean; // custom equality comparator comparing the entire key
+    maxAge?: number; // amount of time in milliseconds before the cache will expire
+    maxArgs?: number; // maximum number of arguments to use as key for caching
+    maxSize?: number; // maximum size of cache for this method
+    onCacheAdd?: (cache: Cache) => void; // a callback when a new cache item is added
+    onCacheChange?: (cache: Cache) => void; // a callback when the cache changes
+    onCacheHit?: (cache: Cache) => void; // a callback when an existing cache item is retrieved
+    onExpire?: (key: any) => void; // a callback when a cache item expires
+    profileName?: string; // a custom name to associate stats for the method to
+    serializer?: (...args: any[]) => any; // provide a serializer and override default,
+    shouldSerializeFunctions?: boolean; // should functions be included in the serialization of multiple parameters
+    transformArgs?: (args: any[]) => any[]; // transform the args prior to storage as key
+    updateExpire?: boolean; // should the expiration be updated when cache is hit
+  }
+
   function compose<T extends Fn>(...fns: Array<Moizer<T>>): Moizer<T>;
 
   function deep<T extends Fn>(t: T, o?: Options): T;
@@ -47,6 +49,4 @@ declare namespace moize {
   function simple<T extends Fn>(t: T, o?: Options): T;
 }
 
-export function collectStats<T extends Fn>(): void;
-
-export default moize;
+export function collectStats<T extends moize.Fn>(): void;


### PR DESCRIPTION
Follow recommendations from DefinitelyTyped (https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-function-d-ts.html).

Fixes error in Typescript triggered in the following code:
    import moize from "moize";
    export memoize = moize.maxSize(5);

Error: "Exported variable 'memoize' has or is using name 'Options' from external module '...' but cannot be named"