### PR TITLE
Fix incorrect type overload

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 export as namespace moize;
 export default moize;
 
-declare function moize<T extends moize.Fn>(o: moize.Cache): ((t: T) => T);
+declare function moize<T extends moize.Fn>(o: moize.Options): ((t: T) => T);
 declare function moize<T extends moize.Fn>(t: T, o?: moize.Options): T;
 
 declare namespace moize {


### PR DESCRIPTION
<img width="1095" alt="Screen Shot 2019-12-31 at 15 10 47" src="https://user-images.githubusercontent.com/3064889/71625442-bf92ed00-2bdf-11ea-9e0b-821eb6057638.png">

Should hopefully prevent the following error when using this library with TypeScript 👍 