### PR TITLE
Apply mjs fix to v5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -57,10 +57,10 @@
         [
           "./plugins/search-and-replace.js",
           {
-            "micro-memoize/es/utils": "micro-memoize/mjs/utils",
-            "micro-memoize": "micro-memoize/mjs",
-            "fast-equals": "fast-equals/mjs",
-            "fast-stringify": "fast-stringify/mjs"
+            "micro-memoize/es/utils": "micro-memoize/mjs/utils.mjs",
+            "micro-memoize": "micro-memoize/mjs/index.mjs",
+            "fast-equals": "fast-equals/mjs/index.mjs",
+            "fast-stringify": "fast-stringify/mjs/index.mjs"
           }
         ]
       ],

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "lint:fix": "NODE_ENV=test eslint src --fix",
     "release": "release-it",
     "release:beta": "release-it --config=.release-it.beta.json",
+    "release:scripts": "npm run lint && npm run flow && npm run copy:types && npm run test:coverage && npm run transpile:lib && npm run transpile:es && npm run transpile:mjs && npm run rename:mjs && npm run dist",
     "rename:mjs": "node ./js-to-mjs.js",
     "start": "npm run dev",
     "test": "NODE_PATH=. NODE_ENV=production BABEL_ENV=test ava",


### PR DESCRIPTION
A [recent change for supporting ESM in NodeJS v14](https://github.com/planttheidea/moize/pull/130) fixed the issue in master (which is on next stable major version 6) however it did not solve the issue for current stable major version 5.  This applies the same explicit filepath change to v5 setup.