### PR TITLE
Clean up types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ lib
 es
 mjs
 *.log
-index.d.ts

--- a/__tests__/default.ts
+++ b/__tests__/default.ts
@@ -4,7 +4,6 @@ import moize, { Moized } from '../src/index';
 
 const foo = 'foo';
 const bar = 'bar';
-const baz = 'baz';
 const _default = 'default';
 
 const method = jest.fn(function (one: string, two: string) {

--- a/__tests__/infinite.ts
+++ b/__tests__/infinite.ts
@@ -15,8 +15,8 @@ const methodDefaulted = jest.fn(function (one: string, two = _default) {
     return { one, two };
 });
 
-const memoized = moize(method);
-const memoizedDefaulted = moize(methodDefaulted);
+const memoized = moize.infinite(method);
+const memoizedDefaulted = moize.infinite(methodDefaulted);
 
 describe('moize', () => {
     afterEach(() => {
@@ -108,9 +108,12 @@ describe('moize', () => {
             memoized.set([bar, foo], value);
 
             expect(memoized.cacheSnapshot).toEqual({
-                keys: [[bar, foo]],
-                size: 1,
-                values: [value],
+                keys: [
+                    [bar, foo],
+                    [foo, bar],
+                ],
+                size: 2,
+                values: [value, { one: foo, two: bar }],
             });
         });
 
@@ -152,9 +155,12 @@ describe('moize', () => {
             withNotifiers.set([bar, foo], value);
 
             expect(withNotifiers.cacheSnapshot).toEqual({
-                keys: [[bar, foo]],
-                size: 1,
-                values: [value],
+                keys: [
+                    [bar, foo],
+                    [foo, bar],
+                ],
+                size: 2,
+                values: [value, { one: foo, two: bar }],
             });
 
             expect(withNotifiers.options.onCacheAdd).toHaveBeenCalled();
@@ -172,6 +178,36 @@ describe('moize', () => {
                 keys: [[foo, bar]],
                 size: 1,
                 values: [value],
+            });
+        });
+
+        it('should order the cache by LRU when updating', () => {
+            memoized(foo, bar);
+            memoized(bar, foo);
+
+            expect(memoized.cacheSnapshot).toEqual({
+                keys: [
+                    [bar, foo],
+                    [foo, bar],
+                ],
+                size: 2,
+                values: [
+                    { one: bar, two: foo },
+                    { one: foo, two: bar },
+                ],
+            });
+
+            const value = 'something else';
+
+            memoized.set([foo, bar], value);
+
+            expect(memoized.cacheSnapshot).toEqual({
+                keys: [
+                    [foo, bar],
+                    [bar, foo],
+                ],
+                size: 2,
+                values: [value, { one: bar, two: foo }],
             });
         });
 
@@ -263,14 +299,17 @@ describe('moize', () => {
 
         it('should clear the cache', () => {
             memoized(foo, bar);
+            memoized(bar, baz);
 
             expect(memoized.has([foo, bar])).toBe(true);
+            expect(memoized.has([bar, baz])).toBe(true);
 
             const result = memoized.clear();
 
             expect(memoized.cache.size).toBe(0);
 
             expect(memoized.has([foo, bar])).toBe(false);
+            expect(memoized.has([bar, baz])).toBe(false);
             expect(result).toBe(true);
         });
 
@@ -334,7 +373,7 @@ describe('moize', () => {
 
     describe('properties', () => {
         it('should have the micro-memoize options', () => {
-            const mmResult = microMemoize(method, { maxSize: 1 });
+            const mmResult = microMemoize(method, { maxSize: Infinity });
 
             const { isEqual, ...options } = memoized._microMemoizeOptions;
             const {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,245 @@
+/* eslint-disable */
+
+import { MicroMemoize } from 'micro-memoize/src/types';
+
+export type Fn<Arg extends any = any, Result extends any = any> = (
+    ...args: Arg[]
+) => Result;
+
+export type FunctionalComponent<Props extends object> = Fn<Props> & {
+    displayName?: string;
+};
+
+export type Key<Arg extends any = any> = Arg[];
+export type Value = any;
+
+export type Cache = MicroMemoize.Cache;
+export type MicroMemoizeOptions = MicroMemoize.Options;
+
+export type Expiration = {
+    expirationMethod: () => void;
+    key: Key;
+    timeoutId: ReturnType<typeof setTimeout>;
+};
+
+export type OnCacheOperation = (
+    cache: Cache,
+    options: Options,
+    moized: (...args: any[]) => any
+) => void;
+
+export type IsEqual = (cacheKeyArg: any, keyArg: any) => boolean;
+export type IsMatchingKey = (cacheKey: Key, key: Key) => boolean;
+export type OnExpire = (key: Key) => any;
+export type Serialize = (key: Key) => string[];
+export type TransformKey = (key: Key) => Key;
+
+export type Options = Partial<{
+    isDeepEqual: boolean;
+    isPromise: boolean;
+    isReact: boolean;
+    isSerialized: boolean;
+    isShallowEqual: boolean;
+    matchesArg: IsEqual;
+    matchesKey: IsMatchingKey;
+    maxAge: number;
+    maxArgs: number;
+    maxSize: number;
+    onCacheAdd: OnCacheOperation;
+    onCacheChange: OnCacheOperation;
+    onCacheHit: OnCacheOperation;
+    onExpire: OnExpire;
+    profileName: string;
+    serializer: Serialize;
+    transformArgs: TransformKey;
+    updateExpire: boolean;
+}>;
+
+export type StatsProfile = {
+    calls: number;
+    hits: number;
+};
+
+export type StatsObject = {
+    calls: number;
+    hits: number;
+    usage: string;
+};
+
+export type GlobalStatsObject = StatsObject & {
+    profiles?: Record<string, StatsProfile>;
+};
+
+export type StatsCache = {
+    anonymousProfileNameCounter: number;
+    isCollectingStats: boolean;
+    profiles: Record<string, StatsProfile>;
+};
+
+export type Moizeable = Fn & Record<string, any>;
+
+export type Memoized<OriginalFn extends Moizeable> = MicroMemoize.Memoized<
+    OriginalFn
+>;
+
+export type Moized<
+    OriginalFn extends Moizeable = Moizeable,
+    CombinedOptions extends Options = Options
+> = Memoized<OriginalFn> & {
+    // values
+    _microMemoizeOptions: Pick<
+        CombinedOptions,
+        'isPromise' | 'maxSize' | 'onCacheAdd' | 'onCacheChange' | 'onCacheHit'
+    > & {
+        isEqual: CombinedOptions['matchesArg'];
+        isMatchingKey: CombinedOptions['matchesKey'];
+        transformKey: CombinedOptions['transformArgs'];
+    };
+    cache: Cache;
+    cacheSnapshot: Cache;
+    expirations: Expiration[];
+    expirationsSnapshot: Expiration[];
+    options: CombinedOptions;
+    originalFunction: OriginalFn;
+
+    // react-specific values
+    contextTypes?: Record<string, Function>;
+    defaultProps?: Record<string, any>;
+    displayName?: string;
+    propTypes: Record<string, Function>;
+
+    // methods
+    clear: () => void;
+    clearStats: () => void;
+    get: (key: Key) => any;
+    getStats: () => StatsProfile;
+    has: (key: Key) => boolean;
+    isCollectingStats: () => boolean;
+    isMoized: () => true;
+    keys: () => Cache['keys'];
+    remove: (key: Key) => void;
+    set: (key: Key, value: any) => void;
+    values: () => Cache['values'];
+};
+
+export type MoizeConfiguration<OriginalFn extends Moizeable> = {
+    expirations: Expiration[];
+    options: Options;
+    originalFunction: OriginalFn;
+};
+
+export type CurriedMoize<OriginalOptions> = <
+    CurriedFn extends Moizeable,
+    CurriedOptions extends Options
+>(
+    curriedFn: CurriedFn | CurriedOptions,
+    curriedOptions?: CurriedOptions
+) =>
+    | Moized<CurriedFn, OriginalOptions & CurriedOptions>
+    | CurriedMoize<OriginalOptions & CurriedOptions>;
+
+export interface MaxAge {
+    <MaxAge extends number>(maxAge: MaxAge): Moize<{ maxAge: MaxAge }>;
+    <MaxAge extends number, UpdateExpire extends boolean>(
+        maxAge: MaxAge,
+        expireOptions: UpdateExpire
+    ): Moize<{ maxAge: MaxAge; updateExpire: UpdateExpire }>;
+    <MaxAge extends number, ExpireHandler extends OnExpire>(
+        maxAge: MaxAge,
+        expireOptions: ExpireHandler
+    ): Moize<{ maxAge: MaxAge; onExpire: ExpireHandler }>;
+    <
+        MaxAge extends number,
+        ExpireHandler extends OnExpire,
+        ExpireOptions extends {
+            onExpire: ExpireHandler;
+        }
+    >(
+        maxAge: MaxAge,
+        expireOptions: ExpireOptions
+    ): Moize<{ maxAge: MaxAge; onExpire: ExpireOptions['onExpire'] }>;
+    <
+        MaxAge extends number,
+        UpdateExpire extends boolean,
+        ExpireOptions extends {
+            updateExpire: UpdateExpire;
+        }
+    >(
+        maxAge: MaxAge,
+        expireOptions: ExpireOptions
+    ): Moize<{ maxAge: MaxAge; updateExpire: UpdateExpire }>;
+    <
+        MaxAge extends number,
+        ExpireHandler extends OnExpire,
+        UpdateExpire extends boolean,
+        ExpireOptions extends {
+            onExpire: ExpireHandler;
+            updateExpire: UpdateExpire;
+        }
+    >(
+        maxAge: MaxAge,
+        expireOptions: ExpireOptions
+    ): Moize<{
+        maxAge: MaxAge;
+        onExpire: ExpireHandler;
+        updateExpire: UpdateExpire;
+    }>;
+}
+
+export interface Moize<DefaultOptions extends Options = Options> {
+    <Fn extends Moizeable>(fn: Fn): Moized<Fn, Options & DefaultOptions>;
+    <Fn extends Moizeable, PassedOptions extends Options>(
+        fn: Fn,
+        options: PassedOptions
+    ): Moized<Fn, Options & DefaultOptions & PassedOptions>;
+    <Fn extends Moized<Moizeable>>(fn: Fn): Moized<
+        Fn['fn'],
+        Options & DefaultOptions
+    >;
+    <Fn extends Moized<Moizeable>, PassedOptions extends Options>(
+        fn: Fn,
+        options: PassedOptions
+    ): Moized<Fn['fn'], Options & DefaultOptions & PassedOptions>;
+    <PassedOptions extends Options>(options: PassedOptions): Moize<
+        PassedOptions
+    >;
+
+    clearStats: (profileName?: string) => void;
+    collectStats: (isCollectingStats?: boolean) => void;
+    compose: (...moizers: Moize[]) => Moize;
+    deep: Moize<{ isDeepEqual: true }>;
+    getStats: (profileName?: string) => StatsObject;
+    infinite: Moize;
+    isCollectingStats: () => boolean;
+    isMoized: (value: any) => value is Moized;
+    matchesArg: <Matcher extends IsEqual>(
+        argMatcher: Matcher
+    ) => Moize<{ matchesArg: Matcher }>;
+    matchesKey: <Matcher extends IsMatchingKey>(
+        keyMatcher: Matcher
+    ) => Moize<{ matchesKey: Matcher }>;
+    maxAge: MaxAge;
+    maxArgs: <MaxArgs extends number>(
+        args: MaxArgs
+    ) => Moize<{ maxArgs: MaxArgs }>;
+    maxSize: <MaxSize extends number>(
+        size: MaxSize
+    ) => Moize<{ maxSize: MaxSize }>;
+    profile: <ProfileName extends string>(
+        profileName: ProfileName
+    ) => Moize<{ profileName: ProfileName }>;
+    promise: Moize<{ isPromise: true }>;
+    react: Moize<{ isReact: true }>;
+    serialize: Moize<{ isSerialized: true }>;
+    serializeWith: <Serializer extends Serialize>(
+        serializer: Serializer
+    ) => Moize<{ isSerialized: true; serializer: Serializer }>;
+    shallow: Moize<{ isShallowEqual: true }>;
+    transformArgs: <Transformer extends TransformKey>(
+        transformer: Transformer
+    ) => Moize<{ transformArgs: Transformer }>;
+}
+
+declare const moize: Moize;
+
+export default moize;

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,9 +462,9 @@ moize.maxArgs = function maxArgs(maxArgs: number) {
  * @alias moize.maxSize
  *
  * @description
- * a moized method where the total size of the cache is limited to the value passed
+ * a moized method where the number of arguments used for determining cache is limited to the value passed
  *
- * @param maxSize the maximum size of the cache
+ * @param maxArgs the number of args to base the key on
  * @returns the moizer function
  */
 moize.maxSize = function maxSize(maxSize: number) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -338,18 +338,6 @@ moize.matchesKey = function (keyMatcher: IsMatchingKey) {
     return moize({ matchesKey: keyMatcher });
 };
 
-/**
- * @function
- * @name maxAge
- * @memberof module:moize
- * @alias moize.maxAge
- *
- * @description
- * a moized method where the age of the cache is limited to the number of milliseconds passed
- *
- * @param maxAge the TTL of the value in cache
- * @returns the moizer function
- */
 function maxAge<MaxAge extends number>(
     maxAge: MaxAge
 ): Moize<{ maxAge: MaxAge }>;
@@ -437,8 +425,32 @@ function maxAge<
     return moize({ maxAge });
 }
 
+/**
+ * @function
+ * @name maxAge
+ * @memberof module:moize
+ * @alias moize.maxAge
+ *
+ * @description
+ * a moized method where the age of the cache is limited to the number of milliseconds passed
+ *
+ * @param maxAge the TTL of the value in cache
+ * @returns the moizer function
+ */
 moize.maxAge = maxAge;
 
+/**
+ * @function
+ * @name maxArgs
+ * @memberof module:moize
+ * @alias moize.maxArgs
+ *
+ * @description
+ * a moized method where the number of args used as a cache key is limited to the number passed
+ *
+ * @param maxArgs the number of args to use as a cache key
+ * @returns the moizer function
+ */
 moize.maxArgs = function maxArgs(maxArgs: number) {
     return moize({ maxArgs });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -446,9 +446,9 @@ moize.maxAge = maxAge;
  * @alias moize.maxArgs
  *
  * @description
- * a moized method where the number of args used as a cache key is limited to the number passed
+ * a moized method where the number of arguments used for determining cache is limited to the value passed
  *
- * @param maxArgs the number of args to use as a cache key
+ * @param maxArgs the number of args to base the key on
  * @returns the moizer function
  */
 moize.maxArgs = function maxArgs(maxArgs: number) {
@@ -462,9 +462,9 @@ moize.maxArgs = function maxArgs(maxArgs: number) {
  * @alias moize.maxSize
  *
  * @description
- * a moized method where the number of arguments used for determining cache is limited to the value passed
+ * a moized method where the total size of the cache is limited to the value passed
  *
- * @param maxArgs the number of args to base the key on
+ * @param maxSize the maximum size of the cache
  * @returns the moizer function
  */
 moize.maxSize = function maxSize(maxSize: number) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -350,17 +350,74 @@ moize.matchesKey = function (keyMatcher: IsMatchingKey) {
  * @param maxAge the TTL of the value in cache
  * @returns the moizer function
  */
-moize.maxAge = function maxAge<ExpireHandler>(
-    maxAge: number,
-    expireOptions?: ExpireHandler
+function maxAge<MaxAge extends number>(
+    maxAge: MaxAge
+): Moize<{ maxAge: MaxAge }>;
+function maxAge<MaxAge extends number, UpdateExpire extends boolean>(
+    maxAge: MaxAge,
+    expireOptions: UpdateExpire
+): Moize<{ maxAge: MaxAge; updateExpire: UpdateExpire }>;
+function maxAge<MaxAge extends number, ExpireHandler extends OnExpire>(
+    maxAge: MaxAge,
+    expireOptions: ExpireHandler
+): Moize<{ maxAge: MaxAge; onExpire: ExpireHandler }>;
+function maxAge<
+    MaxAge extends number,
+    ExpireHandler extends OnExpire,
+    ExpireOptions extends {
+        onExpire: ExpireHandler;
+    }
+>(
+    maxAge: MaxAge,
+    expireOptions: ExpireOptions
+): Moize<{ maxAge: MaxAge; onExpire: ExpireOptions['onExpire'] }>;
+function maxAge<
+    MaxAge extends number,
+    UpdateExpire extends boolean,
+    ExpireOptions extends {
+        updateExpire: UpdateExpire;
+    }
+>(
+    maxAge: MaxAge,
+    expireOptions: ExpireOptions
+): Moize<{ maxAge: MaxAge; updateExpire: UpdateExpire }>;
+function maxAge<
+    MaxAge extends number,
+    ExpireHandler extends OnExpire,
+    UpdateExpire extends boolean,
+    ExpireOptions extends {
+        onExpire: ExpireHandler;
+        updateExpire: UpdateExpire;
+    }
+>(
+    maxAge: MaxAge,
+    expireOptions: ExpireOptions
+): Moize<{
+    maxAge: MaxAge;
+    onExpire: ExpireHandler;
+    updateExpire: UpdateExpire;
+}>;
+function maxAge<
+    MaxAge extends number,
+    ExpireHandler extends OnExpire,
+    UpdateExpire extends boolean,
+    ExpireOptions extends {
+        onExpire?: ExpireHandler;
+        updateExpire?: UpdateExpire;
+    }
+>(
+    maxAge: MaxAge,
+    expireOptions?: ExpireHandler | UpdateExpire | ExpireOptions
 ) {
-    const type = typeof expireOptions;
+    if (expireOptions === true) {
+        return moize({
+            maxAge,
+            updateExpire: expireOptions,
+        });
+    }
 
-    if (type === 'object') {
-        const { onExpire, updateExpire } = expireOptions as {
-            onExpire?: OnExpire;
-            updateExpire?: boolean;
-        };
+    if (typeof expireOptions === 'object') {
+        const { onExpire, updateExpire } = expireOptions;
 
         return moize({
             maxAge,
@@ -369,32 +426,19 @@ moize.maxAge = function maxAge<ExpireHandler>(
         });
     }
 
-    if (type === 'function') {
-        return moize({ maxAge, onExpire: expireOptions, updateExpire: true });
-    }
-
-    if (type === 'boolean') {
+    if (typeof expireOptions === 'function') {
         return moize({
             maxAge,
-            updateExpire: expireOptions,
+            onExpire: expireOptions,
+            updateExpire: true,
         });
     }
 
     return moize({ maxAge });
-};
+}
 
-/**
- * @function
- * @name maxArgs
- * @memberof module:moize
- * @alias moize.maxArgs
- *
- * @description
- * a moized method where the number of arguments used for determining cache is limited to the value passed
- *
- * @param maxArgs the number of args to base the key on
- * @returns the moizer function
- */
+moize.maxAge = maxAge;
+
 moize.maxArgs = function maxArgs(maxArgs: number) {
     return moize({ maxArgs });
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,15 +138,67 @@ export type CurriedMoize<OriginalOptions> = <
     | Moized<CurriedFn, OriginalOptions & CurriedOptions>
     | CurriedMoize<OriginalOptions & CurriedOptions>;
 
-export interface Moize<DefaultOptions extends Options = Options>
-    extends Moizeable {
+export interface MaxAge {
+    <MaxAge extends number>(maxAge: MaxAge): Moize<{ maxAge: MaxAge }>;
+    <MaxAge extends number, UpdateExpire extends boolean>(
+        maxAge: MaxAge,
+        expireOptions: UpdateExpire
+    ): Moize<{ maxAge: MaxAge; updateExpire: UpdateExpire }>;
+    <MaxAge extends number, ExpireHandler extends OnExpire>(
+        maxAge: MaxAge,
+        expireOptions: ExpireHandler
+    ): Moize<{ maxAge: MaxAge; onExpire: ExpireHandler }>;
+    <
+        MaxAge extends number,
+        ExpireHandler extends OnExpire,
+        ExpireOptions extends {
+            onExpire: ExpireHandler;
+        }
+    >(
+        maxAge: MaxAge,
+        expireOptions: ExpireOptions
+    ): Moize<{ maxAge: MaxAge; onExpire: ExpireOptions['onExpire'] }>;
+    <
+        MaxAge extends number,
+        UpdateExpire extends boolean,
+        ExpireOptions extends {
+            updateExpire: UpdateExpire;
+        }
+    >(
+        maxAge: MaxAge,
+        expireOptions: ExpireOptions
+    ): Moize<{ maxAge: MaxAge; updateExpire: UpdateExpire }>;
+    <
+        MaxAge extends number,
+        ExpireHandler extends OnExpire,
+        UpdateExpire extends boolean,
+        ExpireOptions extends {
+            onExpire: ExpireHandler;
+            updateExpire: UpdateExpire;
+        }
+    >(
+        maxAge: MaxAge,
+        expireOptions: ExpireOptions
+    ): Moize<{
+        maxAge: MaxAge;
+        onExpire: ExpireHandler;
+        updateExpire: UpdateExpire;
+    }>;
+}
+
+export interface Moize<DefaultOptions extends Options = Options> {
+    <Fn extends Moizeable>(fn: Fn): Moized<Fn, Options & DefaultOptions>;
     <Fn extends Moizeable, PassedOptions extends Options>(
         fn: Fn,
-        options?: PassedOptions
+        options: PassedOptions
     ): Moized<Fn, Options & DefaultOptions & PassedOptions>;
+    <Fn extends Moized<Moizeable>>(fn: Fn): Moized<
+        Fn['fn'],
+        Options & DefaultOptions
+    >;
     <Fn extends Moized<Moizeable>, PassedOptions extends Options>(
         fn: Fn,
-        options?: PassedOptions
+        options: PassedOptions
     ): Moized<Fn['fn'], Options & DefaultOptions & PassedOptions>;
     <PassedOptions extends Options>(options: PassedOptions): Moize<
         PassedOptions
@@ -166,27 +218,16 @@ export interface Moize<DefaultOptions extends Options = Options>
     matchesKey: <Matcher extends IsMatchingKey>(
         keyMatcher: Matcher
     ) => Moize<{ matchesKey: Matcher }>;
-    maxAge: <
-        ExpireHandler extends OnExpire,
-        UpdateExpire extends boolean,
-        ExpireOptions extends {
-            onExpire?: ExpireHandler;
-            updateExpire?: UpdateExpire;
-        },
-        _OnExpire = ExpireHandler | UpdateExpire | ExpireOptions
-    >(
-        age: number,
-        onExpire?: _OnExpire
-    ) => _OnExpire extends ExpireHandler
-        ? Moize<{ onExpire: _OnExpire; updateExpire: true }>
-        : _OnExpire extends true
-        ? Moize<{ updateExpire: true }>
-        : _OnExpire extends UpdateExpire
-        ? Moize<ExpireOptions>
-        : Moize;
-    maxArgs: (args: number) => Moize;
-    maxSize: (size: number) => Moize;
-    profile: (profileName: string) => Moize;
+    maxAge: MaxAge;
+    maxArgs: <MaxArgs extends number>(
+        args: MaxArgs
+    ) => Moize<{ maxArgs: MaxArgs }>;
+    maxSize: <MaxSize extends number>(
+        size: MaxSize
+    ) => Moize<{ maxSize: MaxSize }>;
+    profile: <ProfileName extends string>(
+        profileName: ProfileName
+    ) => Moize<{ profileName: ProfileName }>;
     promise: Moize<{ isPromise: true }>;
     react: Moize<{ isReact: true }>;
     serialize: Moize<{ isSerialized: true }>;


### PR DESCRIPTION
Surface external types and clean up typings for:
- Better overloads on main function and `maxAge`
- Stricter options when `number` or `string`

Also, provide actual default testing in `__tests__/default.ts` and move existing `moize.infinite` testing to `__tests__/infinite.ts`.