### PR TITLE
update `Moized.prototype.render` to render a valid React element

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  trailingComma: 'es5',
+  semi: true,
+  singleQuote: true,
+  tabWidth: 4,
+};

--- a/DEV_ONLY/react.tsx
+++ b/DEV_ONLY/react.tsx
@@ -7,7 +7,7 @@ type Props = {
     bar?: string;
     fn: (...args: any[]) => any;
     key?: string;
-    object?: object;
+    object?: Record<string, any>;
     value?: any;
 };
 

--- a/DEV_ONLY/react.tsx
+++ b/DEV_ONLY/react.tsx
@@ -4,33 +4,33 @@ import ReactDOM from 'react-dom';
 import moize, { Moized } from '../src';
 
 type Props = {
-  bar?: string;
-  fn: (...args: any[]) => any;
-  key?: string;
-  object?: object;
-  value?: any;
+    bar?: string;
+    fn: (...args: any[]) => any;
+    key?: string;
+    object?: object;
+    value?: any;
 };
 
 function ValueBar({ bar, fn, object, value }: Props) {
-  console.count('react');
-  console.log('react element fired', bar, fn, object, value);
+    console.count('react');
+    console.log('react element fired', bar, fn, object, value);
 
-  return (
-    <div>
-      {value} {bar}
-    </div>
-  );
+    return (
+        <div>
+            {value} {bar}
+        </div>
+    );
 }
 
 ValueBar.propTypes = {
-  bar: PropTypes.string.isRequired,
-  fn: PropTypes.func.isRequired,
-  object: PropTypes.object.isRequired,
-  value: PropTypes.string.isRequired,
+    bar: PropTypes.string.isRequired,
+    fn: PropTypes.func.isRequired,
+    object: PropTypes.object.isRequired,
+    value: PropTypes.string.isRequired,
 };
 
 ValueBar.defaultProps = {
-  bar: 'default',
+    bar: 'default',
 };
 
 const Memoized = moize.react(ValueBar);
@@ -40,79 +40,79 @@ const bar = 'bar';
 const baz = 'baz';
 
 const data = [
-  {
-    fn() {
-      return foo;
+    {
+        fn() {
+            return foo;
+        },
+        object: { value: foo },
+        value: foo,
     },
-    object: { value: foo },
-    value: foo,
-  },
-  {
-    bar,
-    fn() {
-      return bar;
+    {
+        bar,
+        fn() {
+            return bar;
+        },
+        object: { value: bar },
+        value: bar,
     },
-    object: { value: bar },
-    value: bar,
-  },
-  {
-    fn() {
-      return baz;
+    {
+        fn() {
+            return baz;
+        },
+        object: { value: baz },
+        value: baz,
     },
-    object: { value: baz },
-    value: baz,
-  },
 ];
 
 type SimpleAppProps = {
-  isRerender?: boolean;
+    isRerender?: boolean;
 };
 
 class SimpleApp extends React.Component<SimpleAppProps> {
-  MoizedComponent: Moized;
+    MoizedComponent: Moized;
 
-  componentDidUpdate() {
-    console.log('post-update stats', this.MoizedComponent.getStats());
-  }
+    componentDidUpdate() {
+        console.log('post-update stats', this.MoizedComponent.getStats());
+    }
 
-  setMoizedComponent = (Ref: { MoizedComponent: Moized }) => {
-    this.MoizedComponent = Ref.MoizedComponent;
-  };
+    setMoizedComponent = (Ref: { MoizedComponent: Moized }) => {
+        this.MoizedComponent = Ref.MoizedComponent;
+    };
 
-  render() {
-    console.log('rendering simple app');
+    render() {
+        console.log('rendering simple app');
 
-    const { isRerender } = this.props;
+        const { isRerender } = this.props;
 
-    return (
-      <div>
-        <h1 style={{ margin: 0 }}>App</h1>
+        return (
+            <div>
+                <h1 style={{ margin: 0 }}>App</h1>
 
-        <div>
-          <h3>Memoized data list</h3>
+                <div>
+                    <h3>Memoized data list</h3>
 
-          {data.map((values, index) => (
-            <Memoized
-              key={`called-${values.value}`}
-              {...values}
-              isDynamic={index === 2 && isRerender}
-              ref={this.setMoizedComponent}
-            />
-          ))}
-        </div>
-      </div>
-    );
-  }
+                    {data.map((values, index) => (
+                        <Memoized
+                            key={`called-${values.value}`}
+                            {...values}
+                            isDynamic={index === 2 && isRerender}
+                            ref={this.setMoizedComponent}
+                        />
+                    ))}
+                </div>
+            </div>
+        );
+    }
 }
 
 export function renderSimple(container: HTMLDivElement) {
-  const simpleAppContainer = document.createElement('div');
+    const simpleAppContainer = document.createElement('div');
 
-  container.appendChild(simpleAppContainer);
+    container.appendChild(simpleAppContainer);
 
-  ReactDOM.render(<SimpleApp />, simpleAppContainer);
+    ReactDOM.render(<SimpleApp />, simpleAppContainer);
 
-  setTimeout(() => {
-    ReactDOM.render(<SimpleApp isRerender />, simpleAppContainer);
-  }, 3000);
+    setTimeout(() => {
+        ReactDOM.render(<SimpleApp isRerender />, simpleAppContainer);
+    }, 3000);
 }

--- a/__tests__/react.tsx
+++ b/__tests__/react.tsx
@@ -135,7 +135,7 @@ describe('moize.react', () => {
             ReactDOM.render(<App id={id} unused={index === 53} />, app);
         });
 
-        // The number of calls is 3 because cache breaks twice, when `unused` prop toggled on the single element.
+        // The number of calls is 3 because cache breaks twice, when `unused` prop is toggled.
         expect(ComponentSpy).toHaveBeenCalledTimes(3);
     });
 
@@ -199,27 +199,8 @@ describe('moize.react', () => {
             ReactDOM.render(<App id={id} unused={index === 53} />, app);
         });
 
-        // The number of calls is 3 because cache breaks twice, when `unused` context value is toggled on the single element.
+        // The number of calls is 3 because cache breaks twice, when `unused` context value is toggled.
         expect(ComponentSpy).toHaveBeenCalledTimes(3);
-    });
-
-    it('should memoize the component renders', () => {
-        type Props = { id: string };
-
-        const Component = ({ id }: Props) => <div id={id} />;
-        const ComponentSpy = jest.fn(Component) as typeof Component;
-        const MoizedComponent = moize.react(ComponentSpy);
-        const App = ({ id }: Props) => <MoizedComponent id={id} />;
-
-        const app = document.createElement('div');
-
-        document.body.appendChild(app);
-
-        new Array(100).fill('id').forEach((id) => {
-            ReactDOM.render(<App id={id} />, app);
-        });
-
-        expect(ComponentSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should memoize on a per-instance basis on render', async () => {

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,6 +1,13 @@
 import { copyStaticProperties } from './instance';
 import { Moize, Moizeable, Moized as MoizedResult, Options } from './types';
 
+// This was stolen from React internals, which allows us to create React elements without needing
+// a dependency on the React library itself.
+const REACT_ELEMENT_TYPE =
+    typeof Symbol === 'function' && Symbol.for
+        ? Symbol.for('react.element')
+        : 0xeac7;
+
 /**
  * @private
  *
@@ -72,10 +79,17 @@ export function createMoizedComponent<OriginalFn extends Moizeable>(
 
     // eslint-disable-next-line react/display-name
     Moized.prototype.render = function (): MoizedElementType {
-        return this.MoizedComponent(this.props, this.context);
+        return {
+            $$typeof: REACT_ELEMENT_TYPE,
+            type: this.MoizedComponent,
+            props: this.props,
+            ref: null,
+            key: null,
+            _owner: null,
+        };
     };
 
-    copyStaticProperties(fn, Moized, ['contextType']);
+    copyStaticProperties(fn, Moized, ['contextType', 'contextTypes']);
 
     Moized.displayName = `Moized(${fn.displayName || fn.name || 'Component'})`;
 

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,5 +1,5 @@
 import { copyStaticProperties } from './instance';
-import { Moize, Moizeable, Moized as MoizedResult, Options } from './types';
+import { Moize, Moizeable, Options } from './types';
 
 // This was stolen from React internals, which allows us to create React elements without needing
 // a dependency on the React library itself.
@@ -68,17 +68,7 @@ export function createMoizedComponent<OriginalFn extends Moizeable>(
 
     Moized.prototype.isReactComponent = {};
 
-    type MoizedElementType = {
-        $$typeof: symbol | number;
-        type: MoizedResult;
-        props: Record<string, unknown>;
-        ref: null;
-        key: null;
-        _owner: null;
-    };
-
-    // eslint-disable-next-line react/display-name
-    Moized.prototype.render = function (): MoizedElementType {
+    Moized.prototype.render = function () {
         return {
             $$typeof: REACT_ELEMENT_TYPE,
             type: this.MoizedComponent,
@@ -86,7 +76,7 @@ export function createMoizedComponent<OriginalFn extends Moizeable>(
             ref: null,
             key: null,
             _owner: null,
-        };
+        } as JSX.Element;
     };
 
     copyStaticProperties(fn, Moized, ['contextType', 'contextTypes']);

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -55,16 +55,6 @@ export function copyStaticProperties(
             }
         }
     });
-
-    // for (const property in originalFn) {
-    //     if (
-    //         skippedProperties.indexOf(property) === -1 &&
-    //         hasOwnProperty.call(originalFn, property)
-    //     ) {
-    //         newFn[property as keyof typeof newFn] =
-    //             originalFn[property as keyof typeof originalFn];
-    //     }
-    // }
 }
 
 /**


### PR DESCRIPTION
Before (for performance, mainly), we were calling the component as a standard function. This change uses it as a standard React element, which allows the use of hooks is allowed. Fixes #139.