### PR TITLE
Add `arguments`, `callee`, and `caller` to skipped properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# moize CHANGELOG
+## 6.0.1
+
+-   [#146](https://github.com/planttheidea/moize/issues/146) - Fix reading deprecated properties on function object
 
 ## 6.0.0
 

--- a/__tests__/default.ts
+++ b/__tests__/default.ts
@@ -96,6 +96,16 @@ describe('moize', () => {
                 maxSize: 5,
             });
         });
+
+        it('should copy static properties from the source function', () => {
+            const fn = (a: any, b: any) => [a, b];
+
+            fn.foo = 'bar';
+
+            const memoized = moize(fn);
+
+            expect(memoized.foo).toBe(fn.foo);
+        });
     });
 
     describe('cache manipulation', () => {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -12,7 +12,10 @@ import {
 } from './types';
 import { createFindKeyIndex } from './utils';
 
-const ALWAYS_SKIPPED_PROPERTIES = {
+const ALWAYS_SKIPPED_PROPERTIES: Record<string, boolean> = {
+    arguments: true,
+    callee: true,
+    caller: true,
     constructor: true,
     length: true,
     name: true,
@@ -37,9 +40,7 @@ export function copyStaticProperties(
 ) {
     Object.getOwnPropertyNames(originalFn).forEach((property) => {
         if (
-            !ALWAYS_SKIPPED_PROPERTIES[
-                property as keyof typeof ALWAYS_SKIPPED_PROPERTIES
-            ] &&
+            !ALWAYS_SKIPPED_PROPERTIES[property] &&
             skippedProperties.indexOf(property) === -1
         ) {
             const descriptor = Object.getOwnPropertyDescriptor(


### PR DESCRIPTION
## Reason for change

As reported in #146 , an error was occuring in React Native that was related to reading deprecated properties:

`'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them`

This error occurs [in strict mode when attempting to read these properties from a function object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_caller_or_arguments_usage), e.g., `fn.arguments`. The error pointed to code that was performing `Object.getOwnPropertyNames` to iterate over them and clone them to the memoized function. Specific properties are never copied (`constructor`, `length`, etc.), however these inaccessible properties were not included.

## Change

Include `arguments`, `callee`, and `caller` in the list of never-copied properties. This avoids the error-causing access, and they should never be copied anyway.