### PR TITLE
Add self-referring property to `moize` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# moize CHANGELOG
+
+## 6.0.3
+
+-   [#153](https://github.com/planttheidea/moize/issues/153) - Fix ESM/CommonJS cross-compatibility issues in NextJS
+
 ## 6.0.2
 
 -   Update dependencies to latest (`fast-equals` in particular to prevent surfacing of [an issue it faced](https://github.com/planttheidea/fast-equals/pull/41))

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ import moize from 'moize/mjs/index.mjs';
 ## CommonJS
 
 ```ts
-const moize = require('moize').default;
+const moize = require('moize');
 ```
 
 # Usage

--- a/__tests__/default.ts
+++ b/__tests__/default.ts
@@ -403,4 +403,11 @@ describe('moize', () => {
             expect(memoized.originalFunction).toBe(method);
         });
     });
+
+    describe('edge cases', () => {
+        it('should have a self-referring `default` property for mixed ESM/CJS environments', () => {
+            // @ts-ignore - `default` is not surfaced because it exists invisibly for edge-case import cross-compatibility
+            expect(moize.default).toBe(moize);
+        });
+    });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -598,7 +598,13 @@ moize.updateCacheForKey = <UpdateWhen extends UpdateCacheForKey>(
     updateCacheForKey: UpdateWhen
 ) => moize({ updateCacheForKey });
 
-// @ts-ignore - Add self-referring `default` property for edge-case cross-compatibility of mixed ESM/CommonJS usage.
-moize.default = moize;
+// Add self-referring `default` property for edge-case cross-compatibility of mixed ESM/CommonJS usage.
+// This property is frozen and non-enumerable to avoid visibility on iteration or accidental overrides.
+Object.defineProperty(moize, 'default', {
+    configurable: false,
+    enumerable: false,
+    value: moize,
+    writable: false,
+});
 
 export default moize;

--- a/src/index.ts
+++ b/src/index.ts
@@ -598,4 +598,7 @@ moize.updateCacheForKey = <UpdateWhen extends UpdateCacheForKey>(
     updateCacheForKey: UpdateWhen
 ) => moize({ updateCacheForKey });
 
+// @ts-ignore - Add self-referring `default` property for edge-case cross-compatibility of mixed ESM/CommonJS usage.
+moize.default = moize;
+
 export default moize;


### PR DESCRIPTION
## Reason for change

In NextJS, which is a mixture of server and browser environments, `moize` had difficulty being imported. Based on the transpiled code, it looks like NextJS may be using the CJS import but expecting an ESM output (meaning a `.default` property exists on the imported object). This creates runtime errors, because no such property exists. In addition, it appears the documentation is out of date for CommonJS usage; `.default` is no longer needed when using `require`.

Should resolve #153 .

## Change

Add a dummy self-referring `.default` property to the exported `moize` object, which should remove the error. This is intentionally not surfaced in the typing definitions, and the property itself is added as a hidden frozen property so that if consumers are doing edge-case operations like `Object.keys(moize)` it will not cause unexpected differences for them.

Also, update the README to reflect correct CommonJS consumption.