### PR TITLE
Provide better function name

### DIFF
--- a/__tests__/default.ts
+++ b/__tests__/default.ts
@@ -408,20 +408,22 @@ describe('moize', () => {
             expect(moize.default).toBe(moize);
         });
 
-        it('should retain the original function name', () => {
+        it('should prefer the `profileName` when provided', () => {
+            function myNamedFunction() {}
+
+            const memoized = moize(myNamedFunction, {
+                profileName: 'custom profile name',
+            });
+
+            expect(memoized.name).toBe('moized(custom profile name)');
+        });
+
+        it('should wrap the original function name', () => {
             function myNamedFunction() {}
 
             const memoized = moize(myNamedFunction);
 
             expect(memoized.name).toBe('moized(myNamedFunction)');
-        });
-
-        it('should fall back to the `profileName` when provided and function name is anonymous', () => {
-            const memoized = moize(() => {}, {
-                profileName: 'custom profile name',
-            });
-
-            expect(memoized.name).toBe('moized(custom profile name)');
         });
 
         it('should have an ultimate fallback for an anonymous function', () => {

--- a/__tests__/default.ts
+++ b/__tests__/default.ts
@@ -346,10 +346,8 @@ describe('moize', () => {
             const mmResult = microMemoize(method, { maxSize: 1 });
 
             const { isEqual, ...options } = memoized._microMemoizeOptions;
-            const {
-                isEqual: _isEqualIgnored,
-                ...resultOptions
-            } = mmResult.options;
+            const { isEqual: _isEqualIgnored, ...resultOptions } =
+                mmResult.options;
 
             expect(options).toEqual(resultOptions);
             expect(isEqual).toBe(sameValueZeroEqual);
@@ -408,6 +406,20 @@ describe('moize', () => {
         it('should have a self-referring `default` property for mixed ESM/CJS environments', () => {
             // @ts-ignore - `default` is not surfaced because it exists invisibly for edge-case import cross-compatibility
             expect(moize.default).toBe(moize);
+        });
+
+        it('should retain the original function name', () => {
+            function myNamedFunction() {}
+
+            const memoized = moize(myNamedFunction);
+
+            expect(memoized.name).toBe('moized(myNamedFunction)');
+        });
+
+        it('should default the anonymous name', () => {
+            const memoized = moize(() => {});
+
+            expect(memoized.name).toBe('moized(anonymous)');
         });
     });
 });

--- a/__tests__/default.ts
+++ b/__tests__/default.ts
@@ -416,7 +416,15 @@ describe('moize', () => {
             expect(memoized.name).toBe('moized(myNamedFunction)');
         });
 
-        it('should default the anonymous name', () => {
+        it('should fall back to the `profileName` when provided and function name is anonymous', () => {
+            const memoized = moize(() => {}, {
+                profileName: 'custom profile name',
+            });
+
+            expect(memoized.name).toBe('moized(custom profile name)');
+        });
+
+        it('should have an ultimate fallback for an anonymous function', () => {
             const memoized = moize(() => {});
 
             expect(memoized.name).toBe('moized(anonymous)');

--- a/__tests__/react.tsx
+++ b/__tests__/react.tsx
@@ -95,9 +95,9 @@ describe('moize.react', () => {
         type Props = { id: string; unused?: boolean };
 
         const Component = ({ id }: Props) => <div id={id} />;
-        const ComponentSpy = (jest.fn(
+        const ComponentSpy = jest.fn(
             Component
-        ) as unknown) as typeof Component & {
+        ) as unknown as typeof Component & {
             contextTypes: Record<string, any>;
         };
 
@@ -254,5 +254,17 @@ describe('moize.react', () => {
         await new Promise((resolve) => setTimeout(resolve, timing + 200));
 
         expect(spy).toHaveBeenCalled();
+    });
+
+    describe('edge cases', () => {
+        it('should retain the original function name', () => {
+            function MyComponent(): null {
+                return null;
+            }
+
+            const memoized = moize.react(MyComponent);
+
+            expect(memoized.name).toBe('moized(MyComponent)');
+        });
     });
 });

--- a/__tests__/updateCacheForKey.ts
+++ b/__tests__/updateCacheForKey.ts
@@ -318,4 +318,16 @@ describe('moize.updateCacheForKey', () => {
             );
         });
     });
+
+    describe('edge cases', () => {
+        it('should retain the original function name', () => {
+            function myNamedFunction() {}
+
+            const memoized = moize(myNamedFunction, {
+                updateCacheForKey: () => false,
+            });
+
+            expect(memoized.name).toBe('moized(myNamedFunction)');
+        });
+    });
 });

--- a/src/component.ts
+++ b/src/component.ts
@@ -84,7 +84,7 @@ export function createMoizedComponent<OriginalFn extends Moizeable>(
 
     Moized.displayName = `Moized(${fn.displayName || fn.name || 'Component'})`;
 
-    setName(Moized as MoizedFunction, fn);
+    setName(Moized as MoizedFunction, fn.name, options.profileName);
 
     return Moized;
 }

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,5 +1,6 @@
 import { copyStaticProperties } from './instance';
-import { Moize, Moizeable, Options } from './types';
+import { Moize, Moized as MoizedFunction, Moizeable, Options } from './types';
+import { setName } from './utils';
 
 // This was stolen from React internals, which allows us to create React elements without needing
 // a dependency on the React library itself.
@@ -82,6 +83,8 @@ export function createMoizedComponent<OriginalFn extends Moizeable>(
     copyStaticProperties(fn, Moized, ['contextType', 'contextTypes']);
 
     Moized.displayName = `Moized(${fn.displayName || fn.name || 'Component'})`;
+
+    setName(Moized as MoizedFunction, fn);
 
     return Moized;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,17 +193,18 @@ const moize: Moize = function <
     };
 
     const memoized = memoize(fn, microMemoizeOptions);
-    const moized = createMoizeInstance<Fn, CombinedOptions>(memoized, {
+
+    let moized = createMoizeInstance<Fn, CombinedOptions>(memoized, {
         expirations,
         options: coalescedOptions,
         originalFunction: fn,
     });
 
-    setName(moized, fn);
-
     if (updateCacheForKey) {
-        return createRefreshableMoized<typeof moized>(moized);
+        moized = createRefreshableMoized<typeof moized>(moized);
     }
+
+    setName(moized, (fn as Moizeable).name, options.profileName);
 
     return moized;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import {
     UpdateCacheForKey,
 } from './types';
 import { createRefreshableMoized } from './updateCacheForKey';
-import { combine, compose, isMoized, mergeOptions } from './utils';
+import { combine, compose, isMoized, mergeOptions, setName } from './utils';
 
 export * from './types';
 
@@ -193,12 +193,13 @@ const moize: Moize = function <
     };
 
     const memoized = memoize(fn, microMemoizeOptions);
-
     const moized = createMoizeInstance<Fn, CombinedOptions>(memoized, {
         expirations,
         options: coalescedOptions,
         originalFunction: fn,
     });
+
+    setName(moized, fn);
 
     if (updateCacheForKey) {
         return createRefreshableMoized<typeof moized>(moized);

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -313,14 +313,5 @@ export function createMoizeInstance<
     addInstanceMethods<OriginalFn>(memoized, configuration);
     addInstanceProperties<OriginalFn>(memoized, configuration);
 
-    const originalName = configuration.originalFunction.name || 'anonymous';
-
-    Object.defineProperty(memoized, 'name', {
-        configurable: true,
-        enumerable: false,
-        value: `memoized(${originalName})`,
-        writable: false,
-    });
-
     return memoized as Moized<OriginalFn, CombinedOptions>;
 }

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -77,7 +77,7 @@ export function addInstanceMethods<OriginalFn extends Fn>(
         options.isMatchingKey
     );
 
-    const moized = (memoized as unknown) as Moized<OriginalFn, Options>;
+    const moized = memoized as unknown as Moized<OriginalFn, Options>;
 
     moized.clear = function () {
         const {
@@ -158,11 +158,8 @@ export function addInstanceMethods<OriginalFn extends Fn>(
 
     moized.set = function (key: Key, value: any) {
         const { _microMemoizeOptions, cache, options } = moized;
-        const {
-            onCacheAdd,
-            onCacheChange,
-            transformKey,
-        } = _microMemoizeOptions;
+        const { onCacheAdd, onCacheChange, transformKey } =
+            _microMemoizeOptions;
 
         const cacheKey = transformKey ? transformKey(key) : key;
         const keyIndex = findKeyIndex(cache.keys, cacheKey);
@@ -291,7 +288,7 @@ export function addInstanceProperties<OriginalFn extends Moizeable>(
         },
     });
 
-    const moized = (memoized as unknown) as Moized<OriginalFn, Options>;
+    const moized = memoized as unknown as Moized<OriginalFn, Options>;
 
     copyStaticProperties(originalFunction, moized);
 }
@@ -315,6 +312,15 @@ export function createMoizeInstance<
 ) {
     addInstanceMethods<OriginalFn>(memoized, configuration);
     addInstanceProperties<OriginalFn>(memoized, configuration);
+
+    const originalName = configuration.originalFunction.name || 'anonymous';
+
+    Object.defineProperty(memoized, 'name', {
+        configurable: true,
+        enumerable: false,
+        value: `memoized(${originalName})`,
+        writable: false,
+    });
 
     return memoized as Moized<OriginalFn, CombinedOptions>;
 }

--- a/src/updateCacheForKey.ts
+++ b/src/updateCacheForKey.ts
@@ -1,5 +1,4 @@
 import { copyStaticProperties } from './instance';
-import { setName } from './utils';
 
 import type { Moized } from './types';
 
@@ -38,7 +37,6 @@ export function createRefreshableMoized<MoizedFn extends Moized>(
     } as typeof moized;
 
     copyStaticProperties(moized, refreshableMoized);
-    setName(refreshableMoized, moized.originalFunction);
 
     return refreshableMoized;
 }

--- a/src/updateCacheForKey.ts
+++ b/src/updateCacheForKey.ts
@@ -1,4 +1,5 @@
 import { copyStaticProperties } from './instance';
+import { setName } from './utils';
 
 import type { Moized } from './types';
 
@@ -21,7 +22,7 @@ export function createRefreshableMoized<MoizedFn extends Moized>(
      * reverts to the original value if the promise is rejected and there was already a cached
      * value.
      */
-    function refreshableMoized(
+    const refreshableMoized = function refreshableMoized(
         this: any,
         ...args: Parameters<typeof moized.fn>
     ) {
@@ -34,9 +35,10 @@ export function createRefreshableMoized<MoizedFn extends Moized>(
         moized.set(args, result);
 
         return result;
-    }
+    } as typeof moized;
 
     copyStaticProperties(moized, refreshableMoized);
+    setName(refreshableMoized, moized.originalFunction);
 
-    return refreshableMoized as MoizedFn;
+    return refreshableMoized;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -166,8 +166,12 @@ export function isMoized(fn: Moizeable | Moized | Options): fn is Moized {
     return typeof fn === 'function' && (fn as Moizeable).isMoized;
 }
 
-export function setName(fn: Moized, originalFn: Moizeable) {
-    const name = originalFn.name || 'anonymous';
+export function setName(
+    fn: Moized,
+    originalFunctionName: string,
+    profileName: string
+) {
+    const name = originalFunctionName || profileName || 'anonymous';
 
     Object.defineProperty(fn, 'name', {
         configurable: true,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -171,7 +171,7 @@ export function setName(
     originalFunctionName: string,
     profileName: string
 ) {
-    const name = originalFunctionName || profileName || 'anonymous';
+    const name = profileName || originalFunctionName || 'anonymous';
 
     Object.defineProperty(fn, 'name', {
         configurable: true,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,5 +163,16 @@ export function mergeOptions(
 }
 
 export function isMoized(fn: Moizeable | Moized | Options): fn is Moized {
-    return typeof fn === 'function' && fn.isMoized;
+    return typeof fn === 'function' && (fn as Moizeable).isMoized;
+}
+
+export function setName(fn: Moized, originalFn: Moizeable) {
+    const name = originalFn.name || 'anonymous';
+
+    Object.defineProperty(fn, 'name', {
+        configurable: true,
+        enumerable: false,
+        value: `moized(${name})`,
+        writable: true,
+    });
 }


### PR DESCRIPTION
## Reason for change

In #161 , it was requested to provide a more descriptive function name for identification in dev tools. Since ES2015, we can provide a custom `name` property on a function via `Object.defineProperty`, so we can!

## Change

Set the name of the memoized function based on the original function and options passed. There is a priority order:
1. If a `profileName` is provided in options, use it
2. If the function to memoize has a `name`, use it
3. If no `profileName` or function name exists, then default to `anonymous`

This derived name is wrapped in `moized()`. Example of input and output:

```js
function myCustomMethod() {}
const memoized = moize(myCustomMethod);
console.log(memoized.name); // moized(myCustomMethod)
```