### PR TITLE
Issue 176 - Error stack derivation for `profileName` causing OOM crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.1.2
 
--   [#176](https://github.com/planttheidea/moize/issues/176`) - Remove use of `new Error().stack` in derivation of fallback `profileName`, due to potential for OOM crashes in specific scenarios
+-   [#176](https://github.com/planttheidea/moize/issues/176) - Remove use of `new Error().stack` in derivation of fallback `profileName`, due to potential for OOM crashes in specific scenarios
 
 ## 6.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # moize CHANGELOG
 
+## 6.1.2
+
+-   [#176](https://github.com/planttheidea/moize/issues/176`) - Remove use of `new Error().stack` in derivation of fallback `profileName`, due to potential for OOM crashes in specific scenarios
+
 ## 6.1.1
 
 -   Update `fast-equals` to latest major version

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ memoized('one'); // will expire key after 30 seconds, or 3 expiration attempts
 
 ## profileName
 
-_defaults to function name and file/line location_
+_defaults to function name when it exists, or `Anonymous {count}` otherwise_
 
 Name to use as unique identifier for the function when collecting statistics.
 
@@ -571,7 +571,7 @@ This is also available via the shortcut method of [`moize.profile`](#moizeprofil
 const memoized = moize.profile('profile-name')(fn);
 ```
 
-**NOTE**: You must be collecting statistics for this option to take effect.
+**NOTE**: You must be collecting statistics for this option to provide value, as it is the identifier used for statistics collection.
 
 ## serializer
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
   - [moize.maxAge](#moizemaxage)
   - [moize.maxArgs](#moizemaxargs)
   - [moize.maxSize](#moizemaxsize)
+  - [moize.profile](#moizeprofile)
   - [moize.promise](#moizepromise)
   - [moize.react](#moizereact)
   - [moize.serialize](#moizeserialize)
@@ -780,6 +781,20 @@ const fn = (one: string, two: string) => `${one} ${two}`;
 export default moize.maxSize(5)(fn);
 ```
 
+## moize.profile
+
+Pre-applies the [`profileName`](#profilename) option as a curriable method.
+
+```ts
+import moize from 'moize';
+
+const fn = (one: string, two: string) => `${one} ${two}`;
+
+export default moize.profile('my fancy identity')(fn);
+```
+
+**NOTE**: You must be collecting statistics for this option to provide value, as it is the identifier used for statistics collection.
+
 ## moize.promise
 
 Pre-applies the [`isPromise`](#ispromise) and [`updateExpire`](#updateexpire) options. The `updateExpire` option does nothing if [`maxAge`](#maxage) is not also applied, but ensures that the expiration begins at the resolution of the promise rather than the instantiation of it.
@@ -1037,6 +1052,8 @@ moize.collectStats(true); // start collecting stats
 moize.collectStats(); // same as passing true
 moize.collectStats(false); // stop collecting stats
 ```
+
+**NOTE**: If collecting statistics, it is recommended to provide a custom [`profileName`](#profilename) or use [`moize.profile()`](#moizeprofile) for all memoized functions. This allows easier mapping of resulting statistics to their origin function when it has a common name or is anonymous.
 
 ## getStats([profileName])
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -92,35 +92,11 @@ export function createOnCacheHitIncrementCallsAndHits(options: Options) {
 export function getDefaultProfileName(
     fn: Fn | FunctionalComponent<Record<string, unknown>>
 ) {
-    const stack = new Error().stack;
-    const fnName =
+    return (
         (fn as FunctionalComponent<Record<string, unknown>>).displayName ||
         fn.name ||
-        `Anonymous ${statsCache.anonymousProfileNameCounter++}`;
-
-    if (!stack) {
-        return fnName;
-    }
-
-    const lines = stack.split('\n').slice(3);
-
-    let line: string;
-    let profileNameLocation: string;
-
-    for (let index = 0; index < lines.length; index++) {
-        line = lines[index];
-
-        if (
-            line.indexOf('/moize/') === -1 &&
-            line.indexOf(' (native)') === -1 &&
-            line.indexOf(' Function.') === -1
-        ) {
-            profileNameLocation = line.replace(/\n/g, '\\n').trim();
-            break;
-        }
-    }
-
-    return profileNameLocation ? `${fnName} ${profileNameLocation}` : fnName;
+        `Anonymous ${statsCache.anonymousProfileNameCounter++}`
+    );
 }
 
 /**
@@ -212,9 +188,7 @@ export function getStats(profileName?: string): GlobalStatsObject {
  * @param {Options} options the options passed to the moizer
  * @returns {Object} the options specific to keeping stats
  */
-export function getStatsOptions(
-    options: Options
-): {
+export function getStatsOptions(options: Options): {
     onCacheAdd?: OnCacheOperation;
     onCacheHit?: OnCacheOperation;
 } {


### PR DESCRIPTION
## Reason for change

The derivation of a default `profileName` involved creating a dummy error and inspecting the stack trace. This was meant to provide additional context about the original function call, in case it was a name shared with other functions or an anonymous function. However, this introspection can have potentially serious costs for projects that have large source maps, and can cause OOM crashes (seen in #176 ).

## Change

Remove the use of the dummy error stack entirely, instead simply using the original tiered value alone:

- If `displayName` property exists, use it
- Else if `name` property is populated, use it
- Else use `Anonymous` plus an internal counter to separate multiple anonymous functions

The use of the dummy error and stack introspection was never a documented feature, so I'm not considering this a breaking change.