### PR TITLE
[Typings] Fix typings for `mjs`

### DIFF
--- a/es-to-mjs.js
+++ b/es-to-mjs.js
@@ -5,42 +5,56 @@ const path = require('path');
 
 const pkg = require('./package.json');
 
-const SOURCE = path.join(__dirname, pkg.module);
-const SOURCE_MAP = `${SOURCE}.map`;
-const DESTINATION = path.join(__dirname, 'mjs', 'index.mjs');
-const DESTINATION_MAP = `${DESTINATION}.map`;
+const BASE_PATH = __dirname;
+const SOURCE_ENTRY = path.join(BASE_PATH, pkg.module);
+const SOURCE_MAP = `${SOURCE_ENTRY}.map`;
+const SOURCE_TYPES = path.join(BASE_PATH, 'index.d.ts');
+const DESTINATION = 'mjs';
+const DESTINATION_ENTRY = path.join(BASE_PATH, DESTINATION, 'index.mjs');
+const DESTINATION_MAP = `${DESTINATION_ENTRY}.map`;
+const DESTINATION_TYPES = path.join(BASE_PATH, DESTINATION, 'index.d.mts');
 
-const getFileName = (filename) => {
-  const split = filename.split('/');
-
-  return split[split.length - 1];
-};
+function getFileName(filename) {
+    return filename.replace(`${BASE_PATH}/`, '');
+}
 
 try {
-  if (!fs.existsSync(path.join(__dirname, 'mjs'))) {
-    fs.mkdirSync(path.join(__dirname, 'mjs'));
-  }
+    if (!fs.existsSync(path.join(__dirname, 'mjs'))) {
+        fs.mkdirSync(path.join(__dirname, 'mjs'));
+    }
 
-  fs.copyFileSync(SOURCE, DESTINATION);
+    fs.copyFileSync(SOURCE_ENTRY, DESTINATION_ENTRY);
 
-  const contents = fs
-    .readFileSync(DESTINATION, { encoding: 'utf8' })
-    .replace('fast-equals', 'fast-equals/dist/fast-equals.mjs')
-    .replace('fast-stringify', 'fast-stringify/mjs/index.mjs')
-    .replace('micro-memoize', 'micro-memoize/mjs/index.mjs')
-    .replace(/\/\/# sourceMappingURL=(.*)/, (match, value) => {
-      return match.replace(value, 'index.mjs.map');
-    });
+    const contents = fs
+        .readFileSync(DESTINATION_ENTRY, { encoding: 'utf8' })
+        .replace('fast-equals', 'fast-equals/dist/fast-equals.mjs')
+        .replace('fast-stringify', 'fast-stringify/mjs/index.mjs')
+        .replace('micro-memoize', 'micro-memoize/mjs/index.mjs')
+        .replace(/\/\/# sourceMappingURL=(.*)/, (match, value) => {
+            return match.replace(value, 'index.mjs.map');
+        });
 
-  fs.writeFileSync(DESTINATION, contents, { encoding: 'utf8' });
+    fs.writeFileSync(DESTINATION_ENTRY, contents, { encoding: 'utf8' });
 
-  console.log(`Copied ${getFileName(SOURCE)} to ${getFileName(DESTINATION)}`);
+    console.log(
+        `Copied ${getFileName(SOURCE_ENTRY)} to ${getFileName(
+            DESTINATION_ENTRY
+        )}`
+    );
 
-  fs.copyFileSync(SOURCE_MAP, DESTINATION_MAP);
+    fs.copyFileSync(SOURCE_MAP, DESTINATION_MAP);
 
-  console.log(`Copied ${getFileName(SOURCE_MAP)} to ${getFileName(DESTINATION_MAP)}`);
+    console.log(`Copied ${SOURCE_MAP} to ${getFileName(DESTINATION_MAP)}`);
+
+    fs.copyFileSync(SOURCE_TYPES, DESTINATION_TYPES);
+
+    console.log(
+        `Copied ${getFileName(SOURCE_TYPES)} to ${getFileName(
+            DESTINATION_TYPES
+        )}`
+    );
 } catch (error) {
-  console.error(error);
+    console.error(error);
 
-  process.exit(1);
+    process.exit(1);
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,10 @@
 /* eslint-disable */
 
-import { MicroMemoize } from 'micro-memoize/src/types';
+import {
+    Cache as BaseCache,
+    Memoized as BaseMemoized,
+    Options as BaseOptions,
+} from 'micro-memoize';
 
 export type AnyFn = (...args: any[]) => any;
 export type Moizeable = AnyFn & Record<string, any>;
@@ -36,9 +40,9 @@ export type Key<Arg extends any = any> = Arg[];
 export type Value = any;
 
 export type Cache<MoizeableFn extends Moizeable = Moizeable> =
-    MicroMemoize.Cache<MoizeableFn>;
+    BaseCache<MoizeableFn>;
 export type MicroMemoizeOptions<MoizeableFn extends Moizeable = Moizeable> =
-    MicroMemoize.Options<MoizeableFn>;
+    BaseOptions<MoizeableFn>;
 
 export type Expiration = {
     expirationMethod: () => void;
@@ -103,7 +107,7 @@ export type StatsCache = {
 };
 
 export type Memoized<MoizeableFn extends Moizeable = Moizeable> =
-    MicroMemoize.Memoized<MoizeableFn>;
+    BaseMemoized<MoizeableFn>;
 
 export type Moized<
     MoizeableFn extends Moizeable = Moizeable,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "fast-equals": "^3.0.1",
-        "micro-memoize": "^4.0.11"
+        "micro-memoize": "^4.1.2"
     },
     "description": "Blazing fast memoization based on all parameters passed",
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -127,5 +127,5 @@
     },
     "sideEffects": false,
     "types": "./index.d.ts",
-    "version": "6.1.5"
+    "version": "6.1.6-beta.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5906,10 +5906,10 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
-micro-memoize@^4.0.11:
-  version "4.0.14"
-  resolved "https://registry.yarnpkg.com/micro-memoize/-/micro-memoize-4.0.14.tgz#d1239ce2e5831125ac518509f5a23b54e7ca3e17"
-  integrity sha512-2tzWP1w2Hh+r7kCYa4f//jpBEA6dAueiuLco38NxfjF9Py3KCCI7wVOTdCvOhmTC043t+ulclVBdl3v+s+UJIQ==
+micro-memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/micro-memoize/-/micro-memoize-4.1.2.tgz#ce719c1ba1e41592f1cd91c64c5f41dcbf135f36"
+  integrity sha512-+HzcV2H+rbSJzApgkj0NdTakkC+bnyeiUxgT6/m7mjcz1CmM22KYFKp+EVj1sWe4UYcnriJr5uqHQD/gMHLD+g==
 
 micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"


### PR DESCRIPTION
## Reason for change
Like `micro-memoize`, the `mjs` imports at `mjs/index.mjs` did not have typings exposed because the declaration file `index.d.ts` is top-level and not referenced in deep-links.

## Change
Update the `es-to-mjs` script to also copy the typings to the `mjs` folder, which worked for `micro-memoize`. I also updated the typings to use the standard exports instead of the `MicroMemoize` namespace.

Resolves #196 .